### PR TITLE
Added possibility of optional args to get_series_episodes

### DIFF
--- a/tvdb_v4_official.py
+++ b/tvdb_v4_official.py
@@ -201,10 +201,11 @@ class TVDB:
         lang: str = None,
         meta=None,
         if_modified_since=None,
+        **kwargs
     ) -> dict:
         """Returns a series episodes dictionary"""
         url = self.url.construct(
-            "series", id, "episodes/" + season_type, lang, page=page, meta=meta
+            "series", id, "episodes/" + season_type, lang, page=page, meta=meta, **kwargs
         )
         return self.request.make_request(url, if_modified_since)
 


### PR DESCRIPTION
Per the docs and Swagger UI, the `series/{id}/episodes/{season-type}` endpoint can contain additional query params (such as `season`, `episodeNumber`, `airDate`)

https://thetvdb.github.io/v4-api/#/Series/getSeriesEpisodes
https://github.com/thetvdb/v4-api/blob/main/docs/swagger.yml#L1807-L1860